### PR TITLE
Corrects what appears to be an error in a docstring.

### DIFF
--- a/src/util/plotting.jl
+++ b/src/util/plotting.jl
@@ -28,7 +28,7 @@ function.
 ```julia
 using Plots
 f = GP(SqExponentialKernel())
-sampleplot(f(rand(10), 10; markersize=5)
+sampleplot(f(rand(10)), 10; markersize=5)
 ```
 The given example plots 10 samples from the given `FiniteGP`. The `markersize` is modified
 from default of 0.5 to 5.


### PR DESCRIPTION
A parenthesis was missing in the docstring, however I'm not sure if `sampleplot()` is doing what is intended...